### PR TITLE
Always display the 'Convert to ETH' button

### DIFF
--- a/resources/conf/settings.toml
+++ b/resources/conf/settings.toml
@@ -1,4 +1,4 @@
 network = "ropsten"
 client_release_channel = "testing"
 client_release_version = "v0.200.0-rc1"
-services_version = "dev" 
+services_version = "dev"

--- a/resources/templates/base.html
+++ b/resources/templates/base.html
@@ -62,11 +62,11 @@
          }
 
          function hasEnoughEthToLaunchRaiden(balance) {
-           return (balance && balance.ETH.as_wei >= REQUIRED_ETH_AS_WEI);
+           return (balance && balance.ETH && balance.ETH.as_wei >= REQUIRED_ETH_AS_WEI);
          }
 
          function hasEnoughRdnToLaunchRaiden(balance) {
-           return (balance && balance.RDN.as_wei >= (0.9 * REQUIRED_RDN_AS_WEI))
+           return (balance && balance.RDN && balance.RDN.as_wei >= (0.9 * REQUIRED_RDN_AS_WEI))
          }
 
          function hasEnoughBalanceToLaunchRaiden(balance) {

--- a/resources/templates/funding.html
+++ b/resources/templates/funding.html
@@ -12,7 +12,7 @@
     by the
     <a href="https://medium.com/raiden-network/raiden-service-bundle-explained-f9bd3f6f358d" target="_blank">
       Raiden Service Bundle</a>.
-    Please fund the Raiden account (with address below) with at least <strong>{{ minimum_eth_required.formatted }}</strong> and <strong>{{ minimum_rdn_required.formatted }}</strong>.</p>
+    Please fund the Raiden account (with address below) with at least <strong>{{ minimum_eth_required.formatted }}</strong> and approx. <strong>{{ minimum_rdn_required.formatted }}</strong>.</p>
   <p><em>If you don't have RDN tokens, send some extra ETH and we can help you use it to buy RDN at a later step.</em></p>
   <div class="transfer-data-display">
     <div>
@@ -29,12 +29,12 @@
       <ul class="action-list">
         <li>
           <button disabled class="hide-when-disabled" id="btn-web3-eth" onClick="sendEthViaWeb3();">
-            Send ETH via web3
+            Send ETH
           </button>
         </li>
         <li>
           <button disabled class="hide-when-disabled" id="btn-web3-rdn" onClick="sendRdnViaWeb3();">
-            Send RDN via web3
+            Send RDN
           </button>
         </li>
       </ul>
@@ -52,7 +52,7 @@
 <div class="action">
   <button disabled
           id="btn-swap"
-          class="link-button hide-when-disabled"
+          class="link-button"
           data-link-url="{{ reverse_url('swap-options', configuration_file.file_name) }}">
     Convert ETH into RDN
   </button>
@@ -183,7 +183,7 @@
    updateDisplay(balance);
 
    button_launch.disabled = !(hasEnoughBalanceToLaunchRaiden(balance));
-   button_swap.disabled = !(balance.ETH && balance.ETH.as_wei > 0 && !hasEnoughRdnToLaunchRaiden(balance));
+   button_swap.disabled = !(balance.ETH && balance.ETH.as_wei > 0);
  }
 
  function generateQRCode(display_element) {

--- a/resources/templates/launch.html
+++ b/resources/templates/launch.html
@@ -69,7 +69,7 @@
    eth_balance_display_elem.classList.toggle("ok", has_enough_eth);
    eth_balance_display_elem.classList.toggle("nok", !has_enough_eth);
 
-   rdn_balance_display_elem.textContent = balance.RDN.formatted;
+   rdn_balance_display_elem.textContent = (balance.RDN && balance.RDN.formatted) || "N/A";
    rdn_balance_display_elem.classList.toggle("ok", has_enough_rdn);
    rdn_balance_display_elem.classList.toggle("nok", !has_enough_rdn);
 


### PR DESCRIPTION
Keeps it enabled as long as there is any ETH on the account. Also changed the wording to indicate that RDN does not be 100% funded to be able to launch