### PR TITLE
Use a detected free port for the web app

### DIFF
--- a/raiden_installer/web.py
+++ b/raiden_installer/web.py
@@ -8,7 +8,8 @@ from urllib.parse import urlparse
 import tornado.ioloop
 import wtforms
 from ethtoken.abi import EIP20_ABI
-from tornado.web import Application, HTTPError, RequestHandler, url
+from tornado.netutil import bind_sockets
+from tornado.web import Application, HTTPError, HTTPServer, RequestHandler, url
 from tornado.websocket import WebSocketHandler
 from wtforms_tornado import Form
 
@@ -554,7 +555,10 @@ if __name__ == "__main__":
         static_path=os.path.join(RESOURCE_FOLDER_PATH, "static"),
         template_path=os.path.join(RESOURCE_FOLDER_PATH, "templates"),
     )
-    app.listen(PORT)
+
+    sockets = bind_sockets(0)
+    server = HTTPServer(app)
+    server.add_sockets(sockets)
 
     if not DEBUG:
         webbrowser.open_new(f"http://localhost:{PORT}")

--- a/raiden_installer/web.py
+++ b/raiden_installer/web.py
@@ -560,6 +560,12 @@ if __name__ == "__main__":
     server = HTTPServer(app)
     server.add_sockets(sockets)
 
+    _, port = sockets[0].getsockname()
+    local_url = f"http://localhost:{port}"
+    log.info(f"Installer page ready on {local_url}")
+
     if not DEBUG:
-        webbrowser.open_new(f"http://localhost:{PORT}")
+        log.info("Should open automatically in browser...")
+        webbrowser.open_new(local_url)
+
     tornado.ioloop.IOLoop.current().start()


### PR DESCRIPTION
Rather than relying on port 8080 being free, detect a free port. We also log a message that the web app is running and where, in case the automatic opening of the browser fails.

Fixes #36 
Fixes #57 
Fixes #85 